### PR TITLE
Remove MakerDAO as these are personal views.

### DIFF
--- a/EIPS/eip-2538.md
+++ b/EIPS/eip-2538.md
@@ -60,7 +60,7 @@ Matteo Leibowitz
 Igor Lilic, ConsenSys  
 Matthew "HuntingIsland" Light, Manu DeFi  
 Matt Luongo, Thesis Co-Founder  
-Brian McMichael, MakerDAO  
+Brian McMichael, Ethereum Columbus Organizer 
 Jeremiah Nichol, r/ETHFinance Moderator  
 Spencer Noon  
 Cem Özer, Protocol Engineer  


### PR DESCRIPTION
The Maker Foundation has not released an official stance nor do I want my actions to be construed that they have, so I would prefer to sign as an organizer of Ethereum Columbus instead.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
